### PR TITLE
Feature refactor employees and inbound orders

### DIFF
--- a/cmd/server/dependency_injection.go
+++ b/cmd/server/dependency_injection.go
@@ -70,8 +70,8 @@ func GetHandlers(db *sql.DB) Handlers {
 	// - service
 	buyerSv := buyerService.NewBuyerService(buyerRp)
 	PurchaseOrderSv := purchaseOrderService.NewPurchaseOrderService(purchaseOrderRp)
-	employeeSv := employeeService.NewEmployeeService(employeeRp)
-	inboundOrderSv := inboundOrderService.NewInboundOrderService(inboundOrderRp)
+	employeeSv := employeeService.NewEmployeeService(employeeRp, warehouseRp)
+	inboundOrderSv := inboundOrderService.NewInboundOrderService(inboundOrderRp, employeeRp, warehouseRp)
 	productSv := productService.NewProductService(productRp)
 	productRecordSv := productRecordService.NewProductRecordService(productRecordRp)
 	sectionSv := sectionService.NewSectionService(sectionRp)

--- a/internal/repository/inbound_order/inbound_order.go
+++ b/internal/repository/inbound_order/inbound_order.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"database/sql"
-	"log"
 
 	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
 	eh "github.com/luisantonisu/wave15-grupo4/pkg/error_handler"
@@ -24,13 +23,13 @@ func (i *InbounderOrderRepository) AlreadyExits(atribute string, value int) bool
 	if err != nil {
 		return false
 	}
-	log.Println(exists)
+
 	return exists
 }
 
 func (i *InbounderOrderRepository) CreateInboundOrder(inboundOrder model.InboundOrderAttributes) (model.InboundOrder, error) {
-	if i.AlreadyExits("employee_id", inboundOrder.EmployeeID) {
-		return model.InboundOrder{}, eh.GetErrAlreadyExists(eh.EMPLOYEE)
+	if i.AlreadyExits("product_batch_id", inboundOrder.ProductBatchID) == false {
+		return model.InboundOrder{}, eh.GetErrForeignKey(eh.PRODUCT_BATCH_ID)
 	}
 
 	if i.AlreadyExits("order_id", inboundOrder.OrderNumber) {
@@ -44,7 +43,7 @@ func (i *InbounderOrderRepository) CreateInboundOrder(inboundOrder model.Inbound
 
 	id, err := row.LastInsertId()
 	if err != nil {
-		return model.InboundOrder{}, err
+		return model.InboundOrder{}, eh.GetErrDatabase(eh.INBOUND_ORDER)
 	}
 
 	var inb model.InboundOrder

--- a/internal/service/employee/employee.go
+++ b/internal/service/employee/employee.go
@@ -2,41 +2,59 @@ package service
 
 import (
 	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
-	repository "github.com/luisantonisu/wave15-grupo4/internal/repository/employee"
+	employeeRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/employee"
+	warehouseRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/warehouse"
 	eh "github.com/luisantonisu/wave15-grupo4/pkg/error_handler"
 )
 
-func NewEmployeeService(rp repository.IEmployee) *EmployeeService {
-	return &EmployeeService{rp: rp}
+func NewEmployeeService(employeeRp employeeRepository.IEmployee, warehouseRp warehouseRepository.IWarehouse) *EmployeeService {
+	return &EmployeeService{
+		employeeRp:  employeeRp,
+		warehouseRp: warehouseRp,
+	}
 }
 
 type EmployeeService struct {
-	rp repository.IEmployee
+	employeeRp  employeeRepository.IEmployee
+	warehouseRp warehouseRepository.IWarehouse
 }
 
 func (h *EmployeeService) GetAll() (map[int]model.Employee, error) {
-	return h.rp.GetAll()
+	return h.employeeRp.GetAll()
 }
 
 func (h *EmployeeService) GetByID(id int) (model.Employee, error) {
-	return h.rp.GetByID(id)
+	return h.employeeRp.GetByID(id)
 }
 
 func (h *EmployeeService) Create(employee model.Employee) (model.Employee, error) {
 	if employee.FirstName == "" || employee.LastName == "" || employee.CardNumberID <= 0 || employee.WarehouseID <= 0 {
 		return model.Employee{}, eh.GetErrInvalidData(eh.EMPLOYEE)
 	}
-	return h.rp.Create(employee.EmployeeAttributes)
+
+	_, err := h.warehouseRp.GetByID(employee.WarehouseID)
+	if err != nil {
+		return model.Employee{}, eh.GetErrForeignKey(eh.WAREHOUSE)
+	}
+
+	return h.employeeRp.Create(employee.EmployeeAttributes)
 }
 
 func (h *EmployeeService) Update(id int, employee model.EmployeeAttributesPtr) (model.Employee, error) {
-	return h.rp.Update(id, employee)
+	if employee.WarehouseID != nil {
+		_, err := h.warehouseRp.GetByID(*employee.WarehouseID)
+		if err != nil {
+			return model.Employee{}, eh.GetErrForeignKey(eh.WAREHOUSE)
+		}
+	}
+
+	return h.employeeRp.Update(id, employee)
 }
 
 func (h *EmployeeService) Delete(id int) error {
-	return h.rp.Delete(id)
+	return h.employeeRp.Delete(id)
 }
 
 func (h *EmployeeService) Report(id int) (map[int]model.InboundOrdersReport, error) {
-	return h.rp.Report(id)
+	return h.employeeRp.Report(id)
 }

--- a/internal/service/inbound_order/inbound_order.go
+++ b/internal/service/inbound_order/inbound_order.go
@@ -2,21 +2,40 @@ package service
 
 import (
 	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
-	repository "github.com/luisantonisu/wave15-grupo4/internal/repository/inbound_order"
+	employeeRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/employee"
+	inboundOrderRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/inbound_order"
+	warehouseRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/warehouse"
 	eh "github.com/luisantonisu/wave15-grupo4/pkg/error_handler"
 )
 
 type InboundOrderService struct {
-	rp repository.IInboundOrder
+	ibOrdRp     inboundOrderRepository.IInboundOrder
+	employeeRp  employeeRepository.IEmployee
+	warehouseRp warehouseRepository.IWarehouse
 }
 
-func NewInboundOrderService(rp repository.IInboundOrder) *InboundOrderService {
-	return &InboundOrderService{rp: rp}
+func NewInboundOrderService(ibOrdRp inboundOrderRepository.IInboundOrder, employeeRp employeeRepository.IEmployee, warehouseRp warehouseRepository.IWarehouse) *InboundOrderService {
+	return &InboundOrderService{
+		ibOrdRp:     ibOrdRp,
+		employeeRp:  employeeRp,
+		warehouseRp: warehouseRp,
+	}
 }
 
 func (h *InboundOrderService) Create(inboundOrder model.InboundOrderAttributes) (model.InboundOrder, error) {
 	if inboundOrder.OrderDate == "" || inboundOrder.EmployeeID <= 0 || inboundOrder.OrderNumber <= 0 || inboundOrder.WarehouseID <= 0 || inboundOrder.ProductBatchID <= 0 {
 		return model.InboundOrder{}, eh.GetErrInvalidData(eh.INBOUND_ORDER)
 	}
-	return h.rp.CreateInboundOrder(inboundOrder)
+
+	_, err := h.employeeRp.GetByID(inboundOrder.EmployeeID)
+	if err != nil {
+		return model.InboundOrder{}, eh.GetErrForeignKey(eh.EMPLOYEE)
+	}
+
+	_, err = h.warehouseRp.GetByID(inboundOrder.WarehouseID)
+	if err != nil {
+		return model.InboundOrder{}, eh.GetErrForeignKey(eh.WAREHOUSE)
+	}
+
+	return h.ibOrdRp.CreateInboundOrder(inboundOrder)
 }

--- a/pkg/error_handler/my_error.go
+++ b/pkg/error_handler/my_error.go
@@ -7,29 +7,30 @@ import (
 )
 
 const (
-	BUYER          = "buyer"
-	EMPLOYEE       = "employee"
-	PRODUCT        = "product"
-	PRODUCT_RECORD = "product record"
-	SECTION        = "section"
-	SELLER         = "seller"
-	WAREHOUSE      = "warehouse"
-	ID             = "id"
-	INVALID_BODY   = "invalid request body"
-	INVALID_ID     = "invalid id"
-	CARD_NUMBER    = "card number ID"
-	WAREHOUSE_CODE = "warehouse code"
-	SECTION_NUMBER = "section number"
-	ORDER_NUMBER   = "order number"
-	INBOUND_ORDER  = "inbound order"
-	PURCHASE_ORDER = "purchase order"
-	COMPANY_ID     = "company ID"
-	LOCALITY       = "locality"
-	COUNTRY_NAME   = "country name"
-	PROVINCE_NAME  = "province name"
-	COUNTRY_ID     = "country ID"
-	PROVINCE_ID    = "province ID"
-	LOCALITY_ID    = "locality ID"
+	BUYER            = "buyer"
+	EMPLOYEE         = "employee"
+	PRODUCT          = "product"
+	PRODUCT_RECORD   = "product record"
+	SECTION          = "section"
+	SELLER           = "seller"
+	WAREHOUSE        = "warehouse"
+	ID               = "id"
+	INVALID_BODY     = "invalid request body"
+	INVALID_ID       = "invalid id"
+	CARD_NUMBER      = "card number ID"
+	WAREHOUSE_CODE   = "warehouse code"
+	SECTION_NUMBER   = "section number"
+	ORDER_NUMBER     = "order number"
+	INBOUND_ORDER    = "inbound order"
+	PURCHASE_ORDER   = "purchase order"
+	COMPANY_ID       = "company ID"
+	LOCALITY         = "locality"
+	COUNTRY_NAME     = "country name"
+	PROVINCE_NAME    = "province name"
+	COUNTRY_ID       = "country ID"
+	PROVINCE_ID      = "province ID"
+	LOCALITY_ID      = "locality ID"
+	PRODUCT_BATCH_ID = "product batch ID"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 	ErrForeignKey    = errors.New("foreign key not found") // 409
 	ErrGettingData   = errors.New("error getting data")    // 500
 	ErrParsingData   = errors.New("error parsing data")    // 500
+	ErrDatabase      = errors.New("database error")        // 500
 )
 
 func GetErrNotFound(entity string) error {
@@ -63,6 +65,14 @@ func GetErrGettingData(entity string) error {
 
 func GetErrParsingData(entity string) error {
 	return fmt.Errorf("%w: %s", ErrParsingData, entity)
+}
+
+func GetErrDatabase(entity string) error {
+	return fmt.Errorf("%w: %s", ErrDatabase, entity)
+}
+
+func GetErrAlreadyExistsCompose(entity1 string, entity2 string) error {
+	return fmt.Errorf("%s with that %s %w", entity1, entity2, ErrAlreadyExists)
 }
 
 func HandleError(err error) (int, string) {


### PR DESCRIPTION
**Overview**
This PR introduces the implementation of the `GET /api/v1/employees/reportInboundOrders?id={employeeId}` endpoint, which retrieves inbound order statistics for employees.

**Changes Made**
- Refactored the backend logic to validate foreign key relationships between the _Employee_ and _InboundOrder_ entities to ensure data integrity.
- Enhanced error handling to provide more informative responses when foreign key validations fail.

**How to Test**
- Pull the branch.
- Send a `GET` request to `/api/v1/employees/reportInboundOrders?id=1` and verify that the response returns the correct number of inbound orders for the specified employee.
- Test the endpoint without the id parameter to ensure it returns the total inbound orders for all employees.
- Verify scenarios where invalid employee IDs are provided and check that the error responses are clear and informative.
- Check for any errors in the server logs and ensure that responses are returned in a consistent JSON format.

Feedback is appreciated!