### PR TITLE
Testing buyer handler

### DIFF
--- a/internal/handler/buyer/buyer_test.go
+++ b/internal/handler/buyer/buyer_test.go
@@ -48,8 +48,8 @@ var (
 		LastName:     &lastName,
 	}
 	buyerRequestUpdate = dto.BuyerRequestDTO{
-		FirstName:    &firstName,
-		LastName:     &lastName,
+		FirstName: &firstName,
+		LastName:  &lastName,
 	}
 	buyerUpdate = model.Buyer{
 		ID: 1,
@@ -100,7 +100,7 @@ func TestBuyerHandler_Create(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 2: bad buyer request - invalid card number ID", func(t *testing.T) {
+	t.Run("case 2: unprocesable entity - invalid card number id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -128,7 +128,7 @@ func TestBuyerHandler_Create(t *testing.T) {
 		buyerService.AssertNotCalled(t, "Create")
 	})
 
-	t.Run("case 3: conflict - card number ID already exists", func(t *testing.T) {
+	t.Run("case 3: conflict - card number id already exists", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -207,7 +207,7 @@ func TestBuyerHandler_GetAll(t *testing.T) {
 		buyerService.AssertExpectations(t)
 	})
 
-	t.Run("case 2: get all buyers successfully no buyers found", func(t *testing.T) {
+	t.Run("case 2: get all buyers successfully, no buyers found", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -227,7 +227,7 @@ func TestBuyerHandler_GetAll(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 3: Internal Server Error - get all buyers  but error occurred", func(t *testing.T) {
+	t.Run("case 3: internal Server Error - get all buyers  but error occurred", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -270,7 +270,7 @@ func TestBuyerHandler_GetByID(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 2: not found - get buyer by id non existent", func(t *testing.T) {
+	t.Run("case 2: not found - get buyer by id, id non existent", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -290,7 +290,7 @@ func TestBuyerHandler_GetByID(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 3: bad request - get buyer by invalid id", func(t *testing.T) {
+	t.Run("case 3: bad request - get buyer by, invalid id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -336,7 +336,7 @@ func TestBuyerHandler_Update(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 2: not found - update buyer by id non existent", func(t *testing.T) {
+	t.Run("case 2: not found - update buyer, id non existent", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -359,7 +359,7 @@ func TestBuyerHandler_Update(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 3: bad request - update buyer invalid id", func(t *testing.T) {
+	t.Run("case 3: bad request - update buyer, invalid id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -367,7 +367,7 @@ func TestBuyerHandler_Update(t *testing.T) {
 
 		body, err := json.Marshal(buyerRequestUpdate)
 		require.NoError(t, err)
-		
+
 		rt := chi.NewRouter()
 		rt.Patch("/buyers/{id}", buyerHandler.Update())
 
@@ -383,7 +383,7 @@ func TestBuyerHandler_Update(t *testing.T) {
 		buyerService.AssertNotCalled(t, "Update")
 	})
 
-	t.Run("case 4: bad request - update buyer invalid body", func(t *testing.T) {
+	t.Run("case 4: bad request - update buyer, invalid body", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -412,7 +412,7 @@ func TestBuyerHandler_Update(t *testing.T) {
 		buyerService.AssertNotCalled(t, "Update")
 	})
 
-	t.Run("case 5: conflict - card number id already exists", func(t *testing.T) {
+	t.Run("case 5: conflict - update buyer, card number id already exists", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -424,7 +424,7 @@ func TestBuyerHandler_Update(t *testing.T) {
 		rt := chi.NewRouter()
 		rt.Patch("/buyers/{id}", buyerHandler.Update())
 
-		// Act 
+		// Act
 		req, res := httptest.NewRequest(http.MethodPatch, "/buyers/2", bytes.NewReader(body)), httptest.NewRecorder()
 		rt.ServeHTTP(res, req)
 
@@ -437,8 +437,8 @@ func TestBuyerHandler_Update(t *testing.T) {
 	})
 }
 
-func TestBuyerHandler_Delete(t *testing.T){
-	t.Run("case 1: delete buyer successfully", func(t *testing.T){
+func TestBuyerHandler_Delete(t *testing.T) {
+	t.Run("case 1: delete buyer successfully", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -455,7 +455,7 @@ func TestBuyerHandler_Delete(t *testing.T){
 		require.Equal(t, http.StatusNoContent, res.Code)
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 2: not found - delete buyer by id non existent", func(t *testing.T){
+	t.Run("case 2: not found - delete buyer, id non existent", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -476,7 +476,7 @@ func TestBuyerHandler_Delete(t *testing.T){
 		buyerService.AssertExpectations(t)
 	})
 
-	t.Run("case 3: bad request - delete buyer invalid id", func(t *testing.T){
+	t.Run("case 3: bad request - delete buyer, invalid id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -497,8 +497,8 @@ func TestBuyerHandler_Delete(t *testing.T){
 	})
 }
 
-func TestBuyerHanlder_Report(t *testing.T){
-	t.Run("case 1: get purchase order report successfully, all buyers", func(t *testing.T){
+func TestBuyerHanlder_Report(t *testing.T) {
+	t.Run("case 1: get purchase order report successfully, all buyers", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -523,7 +523,7 @@ func TestBuyerHanlder_Report(t *testing.T){
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 2: get purchase order report successfully, specific id", func(t *testing.T){
+	t.Run("case 2: get purchase order report successfully, specific id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -548,7 +548,7 @@ func TestBuyerHanlder_Report(t *testing.T){
 		buyerService.AssertExpectations(t)
 	})
 
-	t.Run("case 3: get purchase order report successfully but empty, specific id", func(t *testing.T){
+	t.Run("case 3: get purchase order report successfully but empty, specific id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -569,7 +569,7 @@ func TestBuyerHanlder_Report(t *testing.T){
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertExpectations(t)
 	})
-	t.Run("case 4: Bad request -  get purchase order report, invalid id", func(t *testing.T){
+	t.Run("case 4: Bad request -  get purchase order report, invalid id", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)
@@ -588,7 +588,7 @@ func TestBuyerHanlder_Report(t *testing.T){
 		require.JSONEq(t, expectedBody, res.Body.String())
 		buyerService.AssertNotCalled(t, "PurchaseOrderReport")
 	})
-	t.Run("case 5: Not found - get purchase order report, id non existent", func(t *testing.T){
+	t.Run("case 5: Not found - get purchase order report, id non existent", func(t *testing.T) {
 		// Arrange
 		buyerService := service.NewBuyerServiceMock()
 		buyerHandler := handler.NewBuyerHandler(buyerService)

--- a/internal/handler/buyer/buyer_test.go
+++ b/internal/handler/buyer/buyer_test.go
@@ -1,0 +1,612 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/dto"
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	handler "github.com/luisantonisu/wave15-grupo4/internal/handler/buyer"
+	service "github.com/luisantonisu/wave15-grupo4/internal/service/buyer"
+	eh "github.com/luisantonisu/wave15-grupo4/pkg/error_handler"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	cardNumberId    = "123456"
+	firstName       = "John"
+	lastName        = "Doe"
+	cardNumberIdB   = "654321"
+	firstNameB      = "Jane"
+	lastNameB       = "Doe"
+	buyerAttributes = model.BuyerAttributes{
+		CardNumberId: &cardNumberId,
+		FirstName:    &firstName,
+		LastName:     &lastName,
+	}
+	buyer = model.Buyer{
+		ID:              1,
+		BuyerAttributes: buyerAttributes,
+	}
+	buyerAttributesB = model.BuyerAttributes{
+		CardNumberId: &cardNumberIdB,
+		FirstName:    &firstNameB,
+		LastName:     &lastNameB,
+	}
+	buyerB = model.Buyer{
+		ID:              2,
+		BuyerAttributes: buyerAttributesB,
+	}
+	buyerRequest = dto.BuyerRequestDTO{
+		CardNumberId: &cardNumberId,
+		FirstName:    &firstName,
+		LastName:     &lastName,
+	}
+	buyerRequestUpdate = dto.BuyerRequestDTO{
+		FirstName:    &firstName,
+		LastName:     &lastName,
+	}
+	buyerUpdate = model.Buyer{
+		ID: 1,
+		BuyerAttributes: model.BuyerAttributes{
+			CardNumberId: &cardNumberId,
+			FirstName:    &firstNameB,
+			LastName:     &lastNameB,
+		},
+	}
+	PurchaseOrderReport = model.ReportPurchaseOrders{
+		ID:                  1,
+		CardNumberId:        cardNumberId,
+		FirstName:           firstName,
+		LastName:            lastName,
+		PurchaseOrdersCount: 1,
+	}
+	PurchaseOrderReportB = model.ReportPurchaseOrders{
+		ID:                  2,
+		CardNumberId:        cardNumberIdB,
+		FirstName:           firstNameB,
+		LastName:            lastNameB,
+		PurchaseOrdersCount: 2,
+	}
+)
+
+func TestBuyerHandler_Create(t *testing.T) {
+	t.Run("case 1: create buyer successfully", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Create", mock.Anything).Return(buyer, nil)
+
+		body, err := json.Marshal(buyerRequest)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/buyers", buyerHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/buyers", bytes.NewReader(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":{"id":1,"card_number_id":"123456","first_name":"John","last_name":"Doe"}}`
+		require.Equal(t, http.StatusCreated, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 2: bad buyer request - invalid card number ID", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+
+		body, err := json.Marshal(dto.BuyerRequestDTO{
+			CardNumberId: nil,
+			FirstName:    &firstName,
+			LastName:     &lastName,
+		})
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/buyers", buyerHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/buyers", bytes.NewReader(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Unprocessable Entity","message":"invalid data: card number ID"}`
+		require.Equal(t, http.StatusUnprocessableEntity, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "Create")
+	})
+
+	t.Run("case 3: conflict - card number ID already exists", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Create", mock.Anything).Return(model.Buyer{}, eh.GetErrAlreadyExists(eh.CARD_NUMBER))
+
+		body, err := json.Marshal(buyerRequest)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/buyers", buyerHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/buyers", bytes.NewReader(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"card number ID already exists"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 4: bad request - invalid request body", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+
+		body, err := json.Marshal(`{
+			CardNumberId: 1,
+			FirstName:    &firstName,
+			LastName:     &lastName,
+		}`)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/buyers", buyerHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/buyers", bytes.NewReader(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message":"invalid request body"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "Create")
+	})
+}
+
+func TestBuyerHandler_GetAll(t *testing.T) {
+	t.Run("case 1: get all buyers successfully", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyers := []model.Buyer{buyer, buyerB}
+		buyerService.On("GetAll").Return(buyers, nil)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers", buyerHandler.GetAll())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":[
+			{"id":1,"card_number_id":"123456","first_name":"John","last_name":"Doe"},
+			{"id":2,"card_number_id":"654321","first_name":"Jane","last_name":"Doe"}
+		]}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+
+	t.Run("case 2: get all buyers successfully no buyers found", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("GetAll").Return([]model.Buyer{}, nil)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers", buyerHandler.GetAll())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data": null}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 3: Internal Server Error - get all buyers  but error occurred", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("GetAll").Return([]model.Buyer{}, eh.GetErrDatabase(eh.BUYER))
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers", buyerHandler.GetAll())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Internal Server Error","message": "database error: buyer"}`
+		require.Equal(t, http.StatusInternalServerError, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+}
+
+func TestBuyerHandler_GetByID(t *testing.T) {
+	t.Run("case 1: get buyer by id successfully", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("GetByID", 1).Return(buyer, nil)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/{id}", buyerHandler.GetByID())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/1", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":{"id":1,"card_number_id":"123456","first_name":"John","last_name":"Doe"}}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 2: not found - get buyer by id non existent", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("GetByID", 1).Return(model.Buyer{}, eh.GetErrNotFound(eh.BUYER))
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/{id}", buyerHandler.GetByID())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/1", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Not Found","message": "buyer not found"}`
+		require.Equal(t, http.StatusNotFound, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 3: bad request - get buyer by invalid id", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/{id}", buyerHandler.GetByID())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/invalidId", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message": "invalid id"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "GetByID")
+	})
+}
+
+func TestBuyerHandler_Update(t *testing.T) {
+	t.Run("case 1: update buyer successfully", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Update", 1, mock.Anything).Return(buyerUpdate, nil)
+
+		body, err := json.Marshal(buyerRequestUpdate)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Patch("/buyers/{id}", buyerHandler.Update())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPatch, "/buyers/1", bytes.NewReader(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":{"id":1,"card_number_id":"123456","first_name":"Jane","last_name":"Doe"}}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 2: not found - update buyer by id non existent", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Update", 3, mock.Anything).Return(model.Buyer{}, eh.GetErrNotFound(eh.BUYER))
+
+		body, err := json.Marshal(buyerRequestUpdate)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Patch("/buyers/{id}", buyerHandler.Update())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPatch, "/buyers/3", bytes.NewReader(body)), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Not Found","message": "buyer not found"}`
+		require.Equal(t, http.StatusNotFound, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 3: bad request - update buyer invalid id", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Update", "invalidId", mock.Anything).Return(model.Buyer{}, eh.INVALID_ID)
+
+		body, err := json.Marshal(buyerRequestUpdate)
+		require.NoError(t, err)
+		
+		rt := chi.NewRouter()
+		rt.Patch("/buyers/{id}", buyerHandler.Update())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPatch, "/buyers/invalidId", bytes.NewReader(body)), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message": "invalid id"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("case 4: bad request - update buyer invalid body", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Update", 1, mock.Anything).Return(model.Buyer{}, eh.INVALID_BODY)
+
+		body, err := json.Marshal(`{
+			CardNumberId: 1,
+			FirstName:    &firstName,
+			LastName:     &lastName,
+		}`)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Patch("/buyers/{id}", buyerHandler.Update())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPatch, "/buyers/1", bytes.NewReader(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message":"invalid request body"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("case 5: conflict - card number id already exists", func(t *testing.T) {
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Update", 2, mock.Anything).Return(model.Buyer{}, eh.GetErrAlreadyExists(eh.CARD_NUMBER))
+
+		body, err := json.Marshal(buyerRequestUpdate)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Patch("/buyers/{id}", buyerHandler.Update())
+
+		// Act 
+		req, res := httptest.NewRequest(http.MethodPatch, "/buyers/2", bytes.NewReader(body)), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"card number ID already exists"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+}
+
+func TestBuyerHandler_Delete(t *testing.T){
+	t.Run("case 1: delete buyer successfully", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Delete", 1).Return(nil)
+
+		rt := chi.NewRouter()
+		rt.Delete("/buyers/{id}", buyerHandler.Delete())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodDelete, "/buyers/1", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		require.Equal(t, http.StatusNoContent, res.Code)
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 2: not found - delete buyer by id non existent", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		buyerService.On("Delete", 3).Return(eh.GetErrNotFound(eh.BUYER))
+
+		rt := chi.NewRouter()
+		rt.Delete("/buyers/{id}", buyerHandler.Delete())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodDelete, "/buyers/3", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Not Found","message": "buyer not found"}`
+		require.Equal(t, http.StatusNotFound, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+
+	t.Run("case 3: bad request - delete buyer invalid id", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+
+		rt := chi.NewRouter()
+		rt.Delete("/buyers/{id}", buyerHandler.Delete())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodDelete, "/buyers/invalidId", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message": "invalid id"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "Delete")
+	})
+}
+
+func TestBuyerHanlder_Report(t *testing.T){
+	t.Run("case 1: get purchase order report successfully, all buyers", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		report := []model.ReportPurchaseOrders{PurchaseOrderReport, PurchaseOrderReportB}
+		var id *int
+		buyerService.On("PurchaseOrderReport", id).Return(report, nil)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/reportPurchaseOrders", buyerHandler.Report())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/reportPurchaseOrders", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":[
+			{"id":1,"card_number_id":"123456","first_name":"John","last_name":"Doe","purchase_orders_count":1},
+			{"id":2,"card_number_id":"654321","first_name":"Jane","last_name":"Doe","purchase_orders_count":2}
+		]}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 2: get purchase order report successfully, specific id", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		report := []model.ReportPurchaseOrders{PurchaseOrderReport}
+		id := 1
+		buyerService.On("PurchaseOrderReport", &id).Return(report, nil)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/reportPurchaseOrders", buyerHandler.Report())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/reportPurchaseOrders?id=1", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":[
+			{"id":1,"card_number_id":"123456","first_name":"John","last_name":"Doe","purchase_orders_count":1}
+		]}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+
+	t.Run("case 3: get purchase order report successfully but empty, specific id", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		id := 1
+		buyerService.On("PurchaseOrderReport", &id).Return([]model.ReportPurchaseOrders{}, nil)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/reportPurchaseOrders", buyerHandler.Report())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/reportPurchaseOrders?id=1", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":[]}`
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+	t.Run("case 4: Bad request -  get purchase order report, invalid id", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/reportPurchaseOrders", buyerHandler.Report())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/reportPurchaseOrders?id=invalidId", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message": "invalid id"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertNotCalled(t, "PurchaseOrderReport")
+	})
+	t.Run("case 5: Not found - get purchase order report, id non existent", func(t *testing.T){
+		// Arrange
+		buyerService := service.NewBuyerServiceMock()
+		buyerHandler := handler.NewBuyerHandler(buyerService)
+		id := 1
+		buyerService.On("PurchaseOrderReport", &id).Return([]model.ReportPurchaseOrders{}, eh.GetErrNotFound(eh.BUYER))
+
+		rt := chi.NewRouter()
+		rt.Get("/buyers/reportPurchaseOrders", buyerHandler.Report())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodGet, "/buyers/reportPurchaseOrders?id=1", nil), httptest.NewRecorder()
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Not Found","message": "buyer not found"}`
+		require.Equal(t, http.StatusNotFound, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		buyerService.AssertExpectations(t)
+	})
+}

--- a/internal/service/buyer/buyer_mock.go
+++ b/internal/service/buyer/buyer_mock.go
@@ -33,9 +33,9 @@ func (m *BuyerServiceMock) Delete(id int) error {
 	return args.Error(0)
 }
 
-func (m *BuyerServiceMock) Update(id int, buyer *model.ProductAttributes) (*model.Product, error) {
+func (m *BuyerServiceMock) Update(id int, buyer model.BuyerAttributes) (model.Buyer, error) {
 	args := m.Called(id, buyer)
-	return args.Get(0).(*model.Product), args.Error(1)
+	return args.Get(0).(model.Buyer), args.Error(1)
 }
 
 func (m *BuyerServiceMock) PurchaseOrderReport(id *int) ([]model.ReportPurchaseOrders, error) {

--- a/internal/service/buyer/buyer_test.go
+++ b/internal/service/buyer/buyer_test.go
@@ -112,7 +112,7 @@ func TestBuyerService_GetAll(t *testing.T) {
 		require.Equal(t, buyers, buyersResult)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 2: get all buyers successfully but empty", func(t *testing.T) {
+	t.Run("case 2: get all buyers successfully, no buyers found", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -130,7 +130,7 @@ func TestBuyerService_GetAll(t *testing.T) {
 }
 
 func TestBuyerService_GetById(t *testing.T) {
-	t.Run("case 1: get buyer by ID successfully", func(t *testing.T) {
+	t.Run("case 1: get buyer by id successfully", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -149,7 +149,7 @@ func TestBuyerService_GetById(t *testing.T) {
 		require.Equal(t, buyer, buyerResult)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 2: not found - get buyer by ID non existent", func(t *testing.T) {
+	t.Run("case 2: not found - get buyer by id, id non existent", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -188,7 +188,7 @@ func TestBuyerService_Update(t *testing.T) {
 		require.Equal(t, buyer, buyerResult)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 2: not found - update buyer non existent", func(t *testing.T) {
+	t.Run("case 2: not found - update buyer, id non existent", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -221,7 +221,7 @@ func TestBuyerService_Delete(t *testing.T) {
 		require.NoError(t, err)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 2: not found - delete buyer non existent", func(t *testing.T) {
+	t.Run("case 2: not found - delete buyer, id non existent", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -280,7 +280,7 @@ func TestBuyerService_ReportPurchaseOrder(t *testing.T) {
 		require.Equal(t, report, reportResult)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 3: get purchase order report with id succesfully but empty", func(t *testing.T) {
+	t.Run("case 3: get purchase order report succesfully but empty, specific id", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -295,7 +295,7 @@ func TestBuyerService_ReportPurchaseOrder(t *testing.T) {
 		require.Empty(t, reportResult)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 4: not found - get purchase order report with id non existent", func(t *testing.T) {
+	t.Run("case 4: not found - get purchase order report, id non existent", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)

--- a/internal/service/buyer/buyer_test.go
+++ b/internal/service/buyer/buyer_test.go
@@ -112,7 +112,7 @@ func TestBuyerService_GetAll(t *testing.T) {
 		require.Equal(t, buyers, buyersResult)
 		repo.AssertExpectations(t)
 	})
-	t.Run("case 2: no buyers found", func(t *testing.T) {
+	t.Run("case 2: get all buyers successfully but empty", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -240,7 +240,7 @@ func TestBuyerService_Delete(t *testing.T) {
 }
 
 func TestBuyerService_ReportPurchaseOrder(t *testing.T) {
-	t.Run("case 1: get purchase order report without id successfully", func(t *testing.T) {
+	t.Run("case 1: get purchase order report successfully, all buyers", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)
@@ -261,7 +261,7 @@ func TestBuyerService_ReportPurchaseOrder(t *testing.T) {
 		repo.AssertExpectations(t)
 	})
 
-	t.Run("case 2: get purchase order report with id successfully", func(t *testing.T) {
+	t.Run("case 2: get purchase order report successfully, specific id", func(t *testing.T) {
 		// Arrange
 		repo := repository.NewBuyerRepositoryMock()
 		buyerService := service.NewBuyerService(repo)


### PR DESCRIPTION
**Description**
This pull request adds unit tests for the buyer.go file in the internal/handler/buyer package. The tests cover various scenarios for the GetAll, GetByID, Report, Create, Delete, and Update methods.

**Testing**
- TestBuyerHandler_Create: Added test cases to verify
  - Successful creation
  - Unprocesable entity: Invalid card number Id
  - Conflict: card number id already exists
  - Bad request: invalid request body

- TestBuyerHandler_GetAll: Added test cases to verify
  - Successful retrieval of all buyers
  - Successful retrieval of all buyers but no buyers in database
  - Internal server error: errors from database

- TestBuyerService_GetById: Added test cases to verify
  - Successful retrieval of a buyer by id
  - Not found: buyer id non existent
  - Bad request: invalid id
  
- TestBuyerService_Update: Added test cases to verify
  - Successful update of a buyer
  - Not found: id non existent
  - Bad request: invalid id
  - Bad request: invalid body
  - Conflict: card number id already exists

- TestBuyerService_Delete: Added test cases to verify
  - Successful deletion of a buyer
  - Not found: id non existent
  - Bad request: invalid id

- TestBuyerService_ReportPurchaseOrder: Added test cases to verify
  - Successful retrieval of all reports when no id is sent
  - Successful retrieval of reports when specific id is sent
  - Successful retrieval of reports when specific id is sent, but buyer has no purchase orders
  - Bad request: invalid id
  - Not found: id non existent

**Additional changes**
- Updated test names for buyer/service tests so is the same as handler's for the same test cases

_Feedback is appreciated_