### PR TITLE
Testing purchase order service

### DIFF
--- a/internal/repository/carry/carry_mock.go
+++ b/internal/repository/carry/carry_mock.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type CarryRepositoryMock struct {
+	mock.Mock
+}
+
+func NewCarryRepositoryMock() *CarryRepositoryMock {
+	return &CarryRepositoryMock{}
+}
+
+func (m *CarryRepositoryMock) Create(carry model.Carry) (model.Carry, error) {
+	args := m.Called(carry)
+	return args.Get(0).(model.Carry), args.Error(1)
+}
+
+func (m *CarryRepositoryMock) GetByID(id int) (model.Carry, error) {
+	args := m.Called(id)
+	return args.Get(0).(model.Carry), args.Error(1)
+}
+
+func (m *CarryRepositoryMock) GetByCarryID(id string) (model.Carry, error) {
+	args := m.Called(id)
+	return args.Get(0).(model.Carry), args.Error(1)
+}

--- a/internal/repository/order_status/order_status_mock.go
+++ b/internal/repository/order_status/order_status_mock.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type OrderStatusRepositoryMock struct {
+	mock.Mock
+}
+
+func NewOrderStatusRepositoryMock() *OrderStatusRepositoryMock {
+	return &OrderStatusRepositoryMock{}
+}
+
+func (m *OrderStatusRepositoryMock) GetByID(id int) (model.OrderStatus, error) {
+	args := m.Called(id)
+	return args.Get(0).(model.OrderStatus), args.Error(1)
+}

--- a/internal/repository/purchase_order/purchase_order_mock.go
+++ b/internal/repository/purchase_order/purchase_order_mock.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type PurchaseOrderRepositoryMock struct {
+	mock.Mock
+}
+
+func NewPurchaseOrderRepositoryMock() *PurchaseOrderRepositoryMock {
+	return &PurchaseOrderRepositoryMock{}
+}
+
+func (m *PurchaseOrderRepositoryMock) Create(purchaseOrder model.PurchaseOrderAttributes) (model.PurchaseOrder, error) {
+	args := m.Called(purchaseOrder)
+	return args.Get(0).(model.PurchaseOrder), args.Error(1)
+}

--- a/internal/service/purchase_order/purchase_order.go
+++ b/internal/service/purchase_order/purchase_order.go
@@ -35,6 +35,12 @@ func (s *PurchaseOrderService) Create(purchaseOrder model.PurchaseOrderAttribute
 	if err != nil {
 		return model.PurchaseOrder{}, eh.GetErrForeignKey(eh.BUYER)
 	}
+	
+	// Validate Carrier exist
+	_, err = s.carryRp.GetByID(*purchaseOrder.CarrierID)
+	if err != nil {
+		return model.PurchaseOrder{}, eh.GetErrForeignKey(eh.CARRY)
+	}
 
 	// Validate Order Status exist
 	_, err = s.orderStatusRp.GetByID(*purchaseOrder.OrderStatusID)
@@ -46,12 +52,6 @@ func (s *PurchaseOrderService) Create(purchaseOrder model.PurchaseOrderAttribute
 	_, err = s.warehouseRp.GetByID(*purchaseOrder.WarehouseID)
 	if err != nil {
 		return model.PurchaseOrder{}, eh.GetErrForeignKey(eh.WAREHOUSE)
-	}
-
-	// Validate Carrier exist
-	_, err = s.carryRp.GetByID(*purchaseOrder.CarrierID)
-	if err != nil {
-		return model.PurchaseOrder{}, eh.GetErrForeignKey(eh.CARRY)
 	}
 
 	return s.purchaseOrderRp.Create(purchaseOrder)

--- a/internal/service/purchase_order/purchase_order_test.go
+++ b/internal/service/purchase_order/purchase_order_test.go
@@ -1,0 +1,205 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	purchaseOrderRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/purchase_order"
+	buyerRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/buyer"
+	carryRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/carry"
+	orderStatusRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/order_status"
+	warehouseRepository "github.com/luisantonisu/wave15-grupo4/internal/repository/warehouse"
+	service "github.com/luisantonisu/wave15-grupo4/internal/service/purchase_order"
+	eh "github.com/luisantonisu/wave15-grupo4/pkg/error_handler"
+	"github.com/stretchr/testify/require"
+)
+
+// Variables for testing
+var(
+	orderNumber = "123456"
+	orderDate = "2021-09-01"
+	trackingCode = "TRACK123"
+	buyerId = 1
+	carryId = 1
+	orderStatusId = 1
+	warehouseId = 1
+
+	purchaseOrderAttributes = model.PurchaseOrderAttributes{
+		OrderNumber: &orderNumber,
+		OrderDate: &orderDate,
+		TrackingCode: &trackingCode,
+		BuyerID: &buyerId,
+		CarrierID: &carryId,
+		OrderStatusID: &orderStatusId,
+		WarehouseID: &warehouseId,
+	}
+)
+
+func TestPurchaseOrderService_Create(t *testing.T){
+	t.Run("case 1: create purchase order successfully", func(t *testing.T){
+		// Arrange
+		purchaseOrderRepo := purchaseOrderRepository.NewPurchaseOrderRepositoryMock()
+		buyerRepo := buyerRepository.NewBuyerRepositoryMock()
+		carryRepo := carryRepository.NewCarryRepositoryMock()
+		orderStatusRepo := orderStatusRepository.NewOrderStatusRepositoryMock()
+		warehouseRepo := warehouseRepository.NewWarehouseRepositoryMock()
+		purchaseOrderService := service.NewPurchaseOrderService(purchaseOrderRepo, buyerRepo, carryRepo, orderStatusRepo, warehouseRepo)
+		purchaseOrder := model.PurchaseOrder{
+			ID: 1,
+			PurchaseOrderAttributes: purchaseOrderAttributes,
+		}
+		purchaseOrderRepo.On("Create", purchaseOrderAttributes).Return(purchaseOrder, nil)
+		buyerRepo.On("GetByID", buyerId).Return(model.Buyer{}, nil)
+		carryRepo.On("GetByID", carryId).Return(model.Carry{}, nil)
+		orderStatusRepo.On("GetByID", orderStatusId).Return(model.OrderStatus{}, nil)
+		warehouseRepo.On("GetByID", warehouseId).Return(model.Warehouse{}, nil)	
+
+		// Act
+		purchaseOrderResult, err := purchaseOrderService.Create(purchaseOrderAttributes)
+
+		// Assert
+		require.NoError(t, err)
+		require.NotNil(t, purchaseOrderResult)
+		require.Equal(t, purchaseOrder, purchaseOrderResult)
+		purchaseOrderRepo.AssertExpectations(t)
+		buyerRepo.AssertExpectations(t)
+		carryRepo.AssertExpectations(t)
+		orderStatusRepo.AssertExpectations(t)
+		warehouseRepo.AssertExpectations(t)
+	})
+	t.Run("case 2: conflict - buyer foreing key not found", func(t *testing.T){
+		// Arrange
+		purchaseOrderRepo := purchaseOrderRepository.NewPurchaseOrderRepositoryMock()
+		buyerRepo := buyerRepository.NewBuyerRepositoryMock()
+		carryRepo := carryRepository.NewCarryRepositoryMock()
+		orderStatusRepo := orderStatusRepository.NewOrderStatusRepositoryMock()
+		warehouseRepo := warehouseRepository.NewWarehouseRepositoryMock()
+
+		purchaseOrderService := service.NewPurchaseOrderService(purchaseOrderRepo, buyerRepo, carryRepo, orderStatusRepo, warehouseRepo)
+		buyerRepo.On("GetByID", buyerId).Return(model.Buyer{}, eh.GetErrForeignKey(eh.BUYER))
+
+		// Act
+		purchaseOrderResult, err := purchaseOrderService.Create(purchaseOrderAttributes)
+
+		// Assert
+		require.Error(t, err)
+		require.ErrorIs(t, err, eh.ErrForeignKey)
+		require.Equal(t, eh.GetErrForeignKey(eh.BUYER), err)
+		require.Equal(t, model.PurchaseOrder{}, purchaseOrderResult)
+		purchaseOrderRepo.AssertExpectations(t)
+		buyerRepo.AssertExpectations(t)
+		carryRepo.AssertExpectations(t)
+		orderStatusRepo.AssertExpectations(t)
+		warehouseRepo.AssertExpectations(t)
+	})
+	t.Run("case 3: conflict - carry foreing key not found", func(t *testing.T){
+		// Arrange
+		purchaseOrderRepo := purchaseOrderRepository.NewPurchaseOrderRepositoryMock()
+		buyerRepo := buyerRepository.NewBuyerRepositoryMock()
+		orderStatusRepo := orderStatusRepository.NewOrderStatusRepositoryMock()
+		carryRepo := carryRepository.NewCarryRepositoryMock()
+		warehouseRepo := warehouseRepository.NewWarehouseRepositoryMock()
+
+		purchaseOrderService := service.NewPurchaseOrderService(purchaseOrderRepo, buyerRepo, carryRepo, orderStatusRepo, warehouseRepo)
+		buyerRepo.On("GetByID", buyerId).Return(model.Buyer{}, nil)
+		carryRepo.On("GetByID", carryId).Return(model.Carry{}, eh.GetErrForeignKey(eh.CARRY))
+
+		// Act
+		purchaseOrderResult, err := purchaseOrderService.Create(purchaseOrderAttributes)
+
+		// Assert
+		require.Error(t, err)
+		require.ErrorIs(t, err, eh.ErrForeignKey)
+		require.Equal(t, eh.GetErrForeignKey(eh.CARRY), err)
+		require.Equal(t, model.PurchaseOrder{}, purchaseOrderResult)
+		purchaseOrderRepo.AssertExpectations(t)
+		buyerRepo.AssertExpectations(t)
+		carryRepo.AssertExpectations(t)
+		orderStatusRepo.AssertExpectations(t)
+		warehouseRepo.AssertExpectations(t)
+	})
+	t.Run("case 4: conflict - order status foreing key not found", func(t *testing.T){
+		// Arrange
+		purchaseOrderRepo := purchaseOrderRepository.NewPurchaseOrderRepositoryMock()
+		buyerRepo := buyerRepository.NewBuyerRepositoryMock()
+		carryRepo := carryRepository.NewCarryRepositoryMock()
+		orderStatusRepo := orderStatusRepository.NewOrderStatusRepositoryMock()
+		warehouseRepo := warehouseRepository.NewWarehouseRepositoryMock()
+
+		purchaseOrderService := service.NewPurchaseOrderService(purchaseOrderRepo, buyerRepo, carryRepo, orderStatusRepo, warehouseRepo)
+		buyerRepo.On("GetByID", buyerId).Return(model.Buyer{}, nil)
+		carryRepo.On("GetByID", carryId).Return(model.Carry{}, nil)
+		orderStatusRepo.On("GetByID", orderStatusId).Return(model.OrderStatus{}, eh.GetErrForeignKey(eh.ORDER_STATUS))
+
+		// Act
+		purchaseOrderResult, err := purchaseOrderService.Create(purchaseOrderAttributes)
+
+		// Assert
+		require.Error(t, err)
+		require.ErrorIs(t, err, eh.ErrForeignKey)
+		require.Equal(t, eh.GetErrForeignKey(eh.ORDER_STATUS), err)
+		require.Equal(t, model.PurchaseOrder{}, purchaseOrderResult)
+		purchaseOrderRepo.AssertExpectations(t)
+		buyerRepo.AssertExpectations(t)
+		carryRepo.AssertExpectations(t)
+		orderStatusRepo.AssertExpectations(t)
+		warehouseRepo.AssertExpectations(t)
+	})
+	t.Run("case 5: conflict - warehouse foreing key not found", func(t *testing.T){
+		// Arrange
+		purchaseOrderRepo := purchaseOrderRepository.NewPurchaseOrderRepositoryMock()
+		buyerRepo := buyerRepository.NewBuyerRepositoryMock()
+		carryRepo := carryRepository.NewCarryRepositoryMock()
+		orderStatusRepo := orderStatusRepository.NewOrderStatusRepositoryMock()
+		warehouseRepo := warehouseRepository.NewWarehouseRepositoryMock()
+
+		purchaseOrderService := service.NewPurchaseOrderService(purchaseOrderRepo, buyerRepo, carryRepo, orderStatusRepo, warehouseRepo)
+		buyerRepo.On("GetByID", buyerId).Return(model.Buyer{}, nil)
+		carryRepo.On("GetByID", carryId).Return(model.Carry{}, nil)
+		orderStatusRepo.On("GetByID", orderStatusId).Return(model.OrderStatus{}, nil)
+		warehouseRepo.On("GetByID", warehouseId).Return(model.Warehouse{}, eh.GetErrForeignKey(eh.WAREHOUSE))
+
+		// Act
+		purchaseOrderResult, err := purchaseOrderService.Create(purchaseOrderAttributes)
+
+		// Assert
+		require.Error(t, err)
+		require.ErrorIs(t, err, eh.ErrForeignKey)
+		require.Equal(t, eh.GetErrForeignKey(eh.WAREHOUSE), err)
+		require.Equal(t, model.PurchaseOrder{}, purchaseOrderResult)
+		purchaseOrderRepo.AssertExpectations(t)
+		buyerRepo.AssertExpectations(t)
+		carryRepo.AssertExpectations(t)
+		orderStatusRepo.AssertExpectations(t)
+		warehouseRepo.AssertExpectations(t)
+	})
+	t.Run("case 6: conflict - purchase order number already exists", func(t *testing.T){
+		// Arrange
+		purchaseOrderRepo := purchaseOrderRepository.NewPurchaseOrderRepositoryMock()
+		buyerRepo := buyerRepository.NewBuyerRepositoryMock()
+		carryRepo := carryRepository.NewCarryRepositoryMock()
+		orderStatusRepo := orderStatusRepository.NewOrderStatusRepositoryMock()
+		warehouseRepo := warehouseRepository.NewWarehouseRepositoryMock()
+
+		purchaseOrderService := service.NewPurchaseOrderService(purchaseOrderRepo, buyerRepo, carryRepo, orderStatusRepo, warehouseRepo)
+		buyerRepo.On("GetByID", buyerId).Return(model.Buyer{}, nil)
+		carryRepo.On("GetByID", carryId).Return(model.Carry{}, nil)
+		orderStatusRepo.On("GetByID", orderStatusId).Return(model.OrderStatus{}, nil)
+		warehouseRepo.On("GetByID", warehouseId).Return(model.Warehouse{}, nil)
+		purchaseOrderRepo.On("Create", purchaseOrderAttributes).Return(model.PurchaseOrder{}, eh.GetErrAlreadyExists(eh.ORDER_NUMBER))
+
+		// Act
+		purchaseOrderResult, err := purchaseOrderService.Create(purchaseOrderAttributes)
+
+		// Assert
+		require.Error(t, err)
+		require.ErrorIs(t, err, eh.ErrAlreadyExists)
+		require.Equal(t, eh.GetErrAlreadyExists(eh.ORDER_NUMBER), err)
+		require.Equal(t, model.PurchaseOrder{}, purchaseOrderResult)
+		purchaseOrderRepo.AssertExpectations(t)
+		buyerRepo.AssertExpectations(t)
+		carryRepo.AssertExpectations(t)
+		orderStatusRepo.AssertExpectations(t)
+		warehouseRepo.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
**Description**
This pull request adds unit tests for the purchase_order.go file in the internal/service/purchase_order package. The tests cover various scenarios for the Create method. Also includes the necessary mocks to run these tests.

**Testing**
- TestPurchaseOrderService_Create: Added test cases to verify
  - Successful creation
  - Conflict: buyer, carry, order status and warehouse foreing key not found
  - Conflict: purchase order number already exists

**Additional Changes**
- Added mocks for carry and order status, needed for purchase order testing

_Feedback is appreciated_