### PR TITLE
Testing purchase order handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp/main
 
 #ide settings
 .idea
+.vscode
 
 #Makefile
 Makefile

--- a/internal/handler/purchase_order/purchase_order_test.go
+++ b/internal/handler/purchase_order/purchase_order_test.go
@@ -1,0 +1,166 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/dto"
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	handler "github.com/luisantonisu/wave15-grupo4/internal/handler/purchase_order"
+	service "github.com/luisantonisu/wave15-grupo4/internal/service/purchase_order"
+	eh "github.com/luisantonisu/wave15-grupo4/pkg/error_handler"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	orderNumber   = "123456"
+	orderDate     = "2021-09-01"
+	trackingCode  = "ABC123"
+	buyerID       = 1
+	carrierID     = 1
+	orderStatusID = 1
+	warehouseID   = 1
+
+	purchaseOrderAttributes = model.PurchaseOrderAttributes{
+		OrderNumber:   &orderNumber,
+		OrderDate:     &orderDate,
+		TrackingCode:  &trackingCode,
+		BuyerID:       &buyerID,
+		CarrierID:     &carrierID,
+		OrderStatusID: &orderStatusID,
+		WarehouseID:   &warehouseID,
+	}
+
+	purchaseOrderRequestDTO = dto.PurchaseOrderRequestDTO{
+		OrderNumber:   &orderNumber,
+		OrderDate:     &orderDate,
+		TrackingCode:  &trackingCode,
+		BuyerID:       &buyerID,
+		CarrierID:     &carrierID,
+		OrderStatusID: &orderStatusID,
+		WarehouseID:   &warehouseID,
+	}
+
+	purchaseOrder = model.PurchaseOrder{
+		ID:                      1,
+		PurchaseOrderAttributes: purchaseOrderAttributes,
+	}
+)
+
+func TestCreatePurchaseOrder(t *testing.T) {
+	t.Run("case 1: create purchase order successfully", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+		purchaseOrderService.On("Create", mock.Anything).Return(purchaseOrder, nil)
+
+		body, err := json.Marshal(purchaseOrderRequestDTO)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"data":{"id":1,"order_number":"123456","order_date":"2021-09-01","tracking_code":"ABC123","buyer_id":1,"carrier_id":1,"order_status_id":1,"warehouse_id":1}}`
+		require.Equal(t, http.StatusCreated, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 2: unprocesable entity - invalid order number", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+
+		body, err := json.Marshal(dto.PurchaseOrderRequestDTO{
+			OrderNumber:   nil,
+			OrderDate:     &orderDate,
+			TrackingCode:  &trackingCode,
+			BuyerID:       &buyerID,
+			CarrierID:     &carrierID,
+			OrderStatusID: &orderStatusID,
+			WarehouseID:   &warehouseID,
+		})
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Unprocessable Entity","message":"invalid data: order number"}`
+		require.Equal(t, http.StatusUnprocessableEntity, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 3: conflict - card number id already exists", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+		purchaseOrderService.On("Create", mock.Anything).Return(model.PurchaseOrder{}, eh.GetErrAlreadyExists(eh.ORDER_NUMBER))
+
+		body, err := json.Marshal(purchaseOrderRequestDTO)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"order number already exists"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 4: bad request - invalid body", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+
+		body, err := json.Marshal(`{
+			OrderNumber: 123456,
+			OrderDate: "2021-09-01",
+			TrackingCode: "ABC123",
+			BuyerID: 1,
+			CarrierID: 1,
+			OrderStatusID: 1,
+			WarehouseID: 1,
+		}`)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Bad Request","message":"invalid request body"}`
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+}

--- a/internal/handler/purchase_order/purchase_order_test.go
+++ b/internal/handler/purchase_order/purchase_order_test.go
@@ -132,7 +132,103 @@ func TestCreatePurchaseOrder(t *testing.T) {
 		require.JSONEq(t, expectedBody, res.Body.String())
 		purchaseOrderService.AssertExpectations(t)
 	})
-	t.Run("case 4: bad request - invalid body", func(t *testing.T) {
+	t.Run("case 4: conflict - buyer foreing key not found", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+		purchaseOrderService.On("Create", mock.Anything).Return(model.PurchaseOrder{}, eh.GetErrForeignKey(eh.BUYER))
+
+		body, err := json.Marshal(purchaseOrderRequestDTO)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"buyer foreign key not found"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 5: conflict - carry foreing key not found", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+		purchaseOrderService.On("Create", mock.Anything).Return(model.PurchaseOrder{}, eh.GetErrForeignKey(eh.CARRY))
+
+		body, err := json.Marshal(purchaseOrderRequestDTO)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"carry foreign key not found"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 6: conflict - order status foreing key not found", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+		purchaseOrderService.On("Create", mock.Anything).Return(model.PurchaseOrder{}, eh.GetErrForeignKey(eh.ORDER_STATUS))
+
+		body, err := json.Marshal(purchaseOrderRequestDTO)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"order status foreign key not found"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 7: conflict - warehouse foreing key not found", func(t *testing.T) {
+		// Arrange
+		purchaseOrderService := service.NewPurchaseOrderServiceMock()
+		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)
+		purchaseOrderService.On("Create", mock.Anything).Return(model.PurchaseOrder{}, eh.GetErrForeignKey(eh.WAREHOUSE))
+
+		body, err := json.Marshal(purchaseOrderRequestDTO)
+		require.NoError(t, err)
+
+		rt := chi.NewRouter()
+		rt.Post("/purchaseOrders", purchaseOrderHandler.Create())
+
+		// Act
+		req, res := httptest.NewRequest(http.MethodPost, "/purchaseOrders", bytes.NewBuffer(body)), httptest.NewRecorder()
+		req.Header.Set("Content-Type", "application/json")
+		rt.ServeHTTP(res, req)
+
+		// Assert
+		expectedBody := `{"status": "Conflict","message":"warehouse foreign key not found"}`
+		require.Equal(t, http.StatusConflict, res.Code)
+		require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+		require.JSONEq(t, expectedBody, res.Body.String())
+		purchaseOrderService.AssertExpectations(t)
+	})
+	t.Run("case 8: bad request - invalid body", func(t *testing.T) {
 		// Arrange
 		purchaseOrderService := service.NewPurchaseOrderServiceMock()
 		purchaseOrderHandler := handler.NewPurchaseOrderHandler(purchaseOrderService)

--- a/internal/handler/purchase_order/purchase_order_test.go
+++ b/internal/handler/purchase_order/purchase_order_test.go
@@ -52,7 +52,7 @@ var (
 	}
 )
 
-func TestCreatePurchaseOrder(t *testing.T) {
+func TestPurchaseOrderHandler_Create(t *testing.T) {
 	t.Run("case 1: create purchase order successfully", func(t *testing.T) {
 		// Arrange
 		purchaseOrderService := service.NewPurchaseOrderServiceMock()

--- a/internal/service/purchase_order/purchase_order_mock.go
+++ b/internal/service/purchase_order/purchase_order_mock.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"github.com/luisantonisu/wave15-grupo4/internal/domain/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type PurchaseOrderServiceMock struct {
+	mock.Mock
+}
+
+func NewPurchaseOrderServiceMock() *PurchaseOrderServiceMock {
+	return &PurchaseOrderServiceMock{}
+}
+
+func (m *PurchaseOrderServiceMock) Create(purchaseOrder model.PurchaseOrderAttributes) (model.PurchaseOrder, error) {
+	args := m.Called(purchaseOrder)
+	return args.Get(0).(model.PurchaseOrder), args.Error(1)
+}


### PR DESCRIPTION
**Description**
This pull request adds unit tests for the purchase_order.go file in the internal/handler/purchase_order package. The tests cover various scenarios for the Create method

**Testing**

- TestBuyerHandler_Create: Added test cases to verify
  - Successful creation
  - Unprocessable entity: Invalid order number
  - Conflict: card number id already exists
  - Conflict: foreign keys for buyer, carry, order status and warehouse not found
  - Bad request: invalid request body